### PR TITLE
Bump minimum Erlang/OTP requirement from 22 to 23

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        otp: [22.3, 23.3, 24.2]
+        otp: [23.3, 24.2]
         rebar: [3.18.0]
     steps:
     - uses: actions/checkout@v2
@@ -55,7 +55,7 @@ jobs:
     runs-on: windows-latest
     strategy:
       matrix:
-        otp: [22.3, 23.3, 24.2]
+        otp: [23.3, 24.2]
         rebar: [3.18.0]
     steps:
     - uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -82,4 +82,4 @@ $ rebar3 edoc
 [hexdocs]: https://hexdocs.pm/rebar3_edoc_extensions
 [gh]: https://github.com/vkatsuba/rebar3_edoc_extensions/actions/workflows/ci.yaml
 [gh badge]: https://img.shields.io/github/workflow/status/vkatsuba/rebar3_edoc_extensions/CI?style=flat-square
-[erlang version badge]: https://img.shields.io/badge/erlang-22.X%20to%2024.X-blue.svg?style=flat-square
+[erlang version badge]: https://img.shields.io/badge/erlang-23.X%20to%2024.X-blue.svg?style=flat-square

--- a/rebar.config
+++ b/rebar.config
@@ -10,7 +10,7 @@
 
 {deps, []}.
 
-{minimum_otp_vsn, "22"}.
+{minimum_otp_vsn, "23"}.
 
 {project_plugins, [rebar3_hex, rebar3_format, rebar3_lint, rebar3_edoc_extensions]}.
 


### PR DESCRIPTION
The main reason is that the `rebar3_format` and `rebar3_edoc_extensions` plugins we depend on (yes, there is a circular dependency I don't understand) require Erlang/OTP 23 apparently.

Note that I don't understand why `rebar3_edoc_extensions` fetched from Hex.pm requires Erlang 22, but anyway...