### PR TITLE
Support user-specified CSS

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -30,7 +30,7 @@ jobs:
     - name: Tests
       env:
         ERL_FLAGS: "-enable-feature all"
-      run: rebar3 test
+      run: env DIAGNOSTIC=1 rebar3 test
     - name: Integration tests
       env:
         ERL_FLAGS: "-enable-feature all"

--- a/rebar.config
+++ b/rebar.config
@@ -43,6 +43,7 @@
    ["test/test_app/src/*.erl",
     "test/test_app/*.erl",
     "test/*.erl",
+    "src/*prv.erl",
     "src/*wrapper.erl",
     "src/*export.erl"]},
   {files, ["*.config", "src/*"]}]}.

--- a/src/rebar3_edoc_extensions.hrl
+++ b/src/rebar3_edoc_extensions.hrl
@@ -8,70 +8,67 @@
 
 -define(BODY_CLASSES, "markdown-body language-erlang").
 -define(ADDITIONAL_STYLE,
-        "<style>
-    body {
-      box-sizing: border-box;
-      min-width: 200px;
-      max-width: 980px;
-      margin: 0 auto;
-      padding: 45px;
-    }
-    @media (max-width: 767px) {
-      body {
-        padding: 15px;
-      }
-    }
-    /* Don't apply the table style to the top-level navigation bar. */
-    .navbar table {
-      display: table;
-      width: 100%;
-    }
-    .navbar table tr,
-    .navbar table th,
-    .navbar table td {
-      border: 0;
-    }
-    /* Keep the same font side inside code blocks than everywhere else. */
-    .markdown-body pre code,
-    code[class*=\"language-\"] {
-      font-size: 85%;
-    }
-    /* Force the color for link on code blocks used for @see tags.  */
-    .markdown-body a code,
-    .markdown-body a code span.token {
-      color: var(--color-accent-fg);
-    }
-    /* Copy the style of code blocks. */
-    .markdown-body .spec {
-      background: #f5f2f0;
-      padding: 1em;
-      margin: .5em 0;
-      overflow: auto;
-      border-radius: 6px;
-    }
-    /* Improve margins inside function spec blocks so that:
-        - empty paragraphs don't add useless margins
-        - the final top and bottom margins are equal */
-    .markdown-body .spec p,
-    .markdown-body .spec ul {
-      margin-top: 16px;
-      margin-bottom: 0;
-    }
-    .markdown-body .spec p:first-child,
-    .markdown-body .spec p:empty {
-      margin-top: 0;
-    }
-    /* Put the function prototype in bold characters. */
-    .markdown-body .spec > p > code:first-child {
-      font-weight: bold;
-    }
-    /* Add some margin below the module short description between the table
-       of contents in the Description section. This text isn't in a
-       <p></p>. */
-    .index + p {
-      margin-top: 16px;
-    }
-    </style>").
--define(SYNTAX_HIGHLIGHTING_CSS, "<link href=\"prism.css\" rel=\"stylesheet\" />").
+        "body {
+  box-sizing: border-box;
+  min-width: 200px;
+  max-width: 980px;
+  margin: 0 auto;
+  padding: 45px;
+}
+@media (max-width: 767px) {
+  body {
+    padding: 15px;
+  }
+}
+/* Don't apply the table style to the top-level navigation bar. */
+.navbar table {
+  display: table;
+  width: 100%;
+}
+.navbar table tr,
+.navbar table th,
+.navbar table td {
+  border: 0;
+}
+/* Keep the same font side inside code blocks than everywhere else. */
+.markdown-body pre code,
+code[class*=\"language-\"] {
+  font-size: 85%;
+}
+/* Force the color for link on code blocks used for @see tags.  */
+.markdown-body a code,
+.markdown-body a code span.token {
+  color: var(--color-accent-fg);
+}
+/* Copy the style of code blocks. */
+.markdown-body .spec {
+  background: #f5f2f0;
+  padding: 1em;
+  margin: .5em 0;
+  overflow: auto;
+  border-radius: 6px;
+}
+/* Improve margins inside function spec blocks so that:
+    - empty paragraphs don't add useless margins
+    - the final top and bottom margins are equal */
+.markdown-body .spec p,
+.markdown-body .spec ul {
+  margin-top: 16px;
+  margin-bottom: 0;
+}
+.markdown-body .spec p:first-child,
+.markdown-body .spec p:empty {
+  margin-top: 0;
+}
+/* Put the function prototype in bold characters. */
+.markdown-body .spec > p > code:first-child {
+  font-weight: bold;
+}
+/* Add some margin below the module short description between the table
+   of contents in the Description section. This text isn't in a
+   <p></p>. */
+.index + p {
+  margin-top: 16px;
+}").
 -define(SYNTAX_HIGHLIGHTING_JS, "<script src=\"prism.js\"></script>").
 -define(LANG_REGEX, "none|elixir|erlang").

--- a/src/rebar3_edoc_extensions_export.erl
+++ b/src/rebar3_edoc_extensions_export.erl
@@ -28,11 +28,6 @@
     xmerl_html:'#root#'(Data, Attrs, [], E).
 
 -spec '#element#'(term(), term(), term(), term(), term()) -> term().
-'#element#'(head = Tag, Data, Attrs, Parents, E) ->
-    Data1 = [Data,
-             ?SYNTAX_HIGHLIGHTING_CSS,
-             ?ADDITIONAL_STYLE],
-    xmerl_html:'#element#'(Tag, Data1, Attrs, Parents, E);
 '#element#'(body = Tag, Data, _Attrs, Parents, E) ->
     Data1 = [?SYNTAX_HIGHLIGHTING_JS,
              Data],

--- a/src/rebar3_edoc_extensions_wrapper.erl
+++ b/src/rebar3_edoc_extensions_wrapper.erl
@@ -45,15 +45,8 @@ run(#doclet_gen{app = App} = Cmd, Ctxt) ->
 
 -spec patch_html(list()) -> list().
 patch_html(Html) ->
-    Html1 = re:replace(
-                  Html,
-                  "</head>",
-                  ?SYNTAX_HIGHLIGHTING_CSS "\n"
-                  ?ADDITIONAL_STYLE "\n"
-                  "</head>",
-                  [{return, list}]),
     Html2 = re:replace(
-                  Html1,
+                  Html,
                   "<body +bgcolor=\"[^\"]*\">",
                   "<body class=\"" ?BODY_CLASSES "\">\n"
                   ?SYNTAX_HIGHLIGHTING_JS,

--- a/test/rebar3_edoc_extensions_SUITE.erl
+++ b/test/rebar3_edoc_extensions_SUITE.erl
@@ -63,11 +63,12 @@ test_app(_Config) ->
     {Res, _} = edoc(State),
     {ok, Bin} = file:read_file("test_app/doc/test.html"),
     ?assertEqual(ok, Res),
+    ?assertEqual(true, filelib:is_file("test_app/doc/edoc-extensions.css")),
     ?assertEqual(true, filelib:is_file("test_app/doc/prism.js")),
     ?assertEqual(true, filelib:is_file("test_app/doc/prism.css")),
     ?assertEqual(true, filelib:is_file("test_app/doc/github-markdown.css")),
     ?assertEqual(true, nomatch /= re:run(Bin, "language-erlang")),
-    ?assertEqual(true, nomatch /= re:run(Bin, "prism.js")).
+    ?assertEqual(true, nomatch /= re:run(Bin, "edoc-extensions.css")).
 
 -spec command(list()) -> ok | no_return().
 command(_Config) ->


### PR DESCRIPTION
In other words, the plugin now handles the `stylesheet` option in `edoc_opts`

Instead of patching the HTML files, the plugin creates its own stylesheet and passes it to EDoc using the `stylesheet` option. `github-markdown.css` and `prism.css` are imported from that generated CSS file.

If the user specified his own stylesheet, we can now import it from that generated CSS file. This allows the user to provide his own CSS rules and even override the other stylesheets we import.