### PR TITLE
Rework how user-specified `doclet` and `layout` modules are managed

### DIFF
--- a/src/rebar3_edoc_extensions_wrapper.erl
+++ b/src/rebar3_edoc_extensions_wrapper.erl
@@ -27,19 +27,16 @@
 
 -spec module(term(), list()) -> term().
 module(Element, Options) ->
-    LayoutMod = get_chained_mod(layout, Options),
-    LayoutMod:module(Element, Options).
+    edoc_layout:module(Element, Options).
 
 -spec overview(term(), list()) -> [binary() | list()].
 overview(Element, Options) ->
-    LayoutMod = get_chained_mod(layout, Options),
-    Overview = LayoutMod:overview(Element, Options),
+    Overview = edoc_layout:overview(Element, Options),
     patch_html(Overview).
 
 -spec run(#doclet_gen{}, #?RECORD{}) -> ok | no_return().
 run(#doclet_gen{app = App} = Cmd, #?RECORD{dir = Dir} = Ctxt) ->
-    DocletMod = get_chained_mod(doclet, Ctxt),
-    ok = DocletMod:run(Cmd, Ctxt),
+    ok = edoc_doclet:run(Cmd, Ctxt),
     File = filename:join(Dir, "modules-frame.html"),
     {ok, Content0} = file:read_file(File),
     Content1 = add_toc(App, Content0, Dir),
@@ -48,30 +45,6 @@ run(#doclet_gen{app = App} = Cmd, #?RECORD{dir = Dir} = Ctxt) ->
         ok              -> ok;
         {error, Reason} -> exit({error, Reason})
     end.
-
--spec get_chained_mod(Option, Options | Ctxt) -> Value when
-      Option :: doclet | layout,
-      Options :: [tuple()],
-      Ctxt :: #?RECORD{},
-      Value :: any().
-get_chained_mod(doclet = Option, Options) when is_list(Options) ->
-    get_chained_mod(proplists:get_value(chained_doclet, Options), Option, edoc_doclet);
-get_chained_mod(layout = Option, Options) when is_list(Options) ->
-    get_chained_mod(proplists:get_value(chained_layout, Options), Option, edoc_layout);
-get_chained_mod(Option, Ctxt) when is_tuple(Ctxt) ->
-    #?RECORD{opts = Options} = Ctxt,
-    get_chained_mod(Option, Options).
-
--spec get_chained_mod(Option1, Option2, DefaultOption) -> Value when
-      Option1 :: atom(),
-      Option2 :: doclet | layout,
-      DefaultOption :: atom(),
-      Value :: atom().
-get_chained_mod(undefined, Option, DefaultOption) ->
-    ?DEBUG("Used default option '~p' value for '~p'", [DefaultOption, Option]),
-    DefaultOption;
-get_chained_mod(Option, _, _) ->
-    Option.
 
 -spec patch_html(list()) -> list().
 patch_html(Html) ->


### PR DESCRIPTION
The previous approach had several major issues that couldn't be easily fixed:

1.  I understood how `edoc_{doclet,layout}_chunks` worked incorrectly. I thought that they would generate both the HTML documentation and the EEP-48 doc chunks. That's not the case and they only generate doc chunks. So to get both, we need to run EDoc with `edoc_doclet` and `edoc_layout` in addition to the configured modules.

2.  Calling `edoc_*_chunks` and ignoring the return values (because we want to call `edoc_*` too) broke doc chunks. So it's not possible to chain EDoc backend modules from the backend modules themselves.

3.  The way we overrode EDoc options in the Rebar state was ineffective.

    Rebar supports project- and app-level configurations. The app-level configuration defaults to the project-level one. The `edoc` Rebar command merges them to create the final list of options.

    Because of this, we ended up with duplicated options for those we override in this plugin. For instance, we got two `doclet` modules in the options list: one from the project-level configuration (set by this plugin), one from the app-level configuration (inherited from the project-level configuration before we modify it). And the app-level configuration took precedence, meaning that our backend modules were not used.

This patch brings a new design.

First, the loop over project apps now overrides settings in the app-level configuration. The same settings are removed from the project-level configuration. This ensures that the `edoc` command will get the options we override from the app-level configuration only.

Second, instead of calling the user-configured backend modules from our own modules, we simply call the `edoc` Rebar command twice: once for each set of modules. If the user is using default backends, we simply call `edoc` once for this plugin.
