### PR TITLE
Allow to expand <head/> with the content of `doc/_head.html`

### DIFF
--- a/src/rebar3_edoc_extensions.hrl
+++ b/src/rebar3_edoc_extensions.hrl
@@ -72,6 +72,7 @@ code[class*=\"language-\"] {
 }").
 -define(SYNTAX_HIGHLIGHTING_JS, "<script src=\"prism.js\"></script>").
 -define(LANG_REGEX, "none|elixir|erlang").
+-define(HEAD_ADDON_FILENAME, "_head.html").
 -define(DEBUG(Str, Args), rebar_log:log(debug, Str, Args)).
 -define(INFO(Str, Args), rebar_log:log(info, Str, Args)).
 -define(WARN(Str, Args), rebar_log:log(warn, Str, Args)).

--- a/src/rebar3_edoc_extensions_export.erl
+++ b/src/rebar3_edoc_extensions_export.erl
@@ -28,6 +28,17 @@
     xmerl_html:'#root#'(Data, Attrs, [], E).
 
 -spec '#element#'(term(), term(), term(), term(), term()) -> term().
+'#element#'(head = Tag, Data, Attrs, Parents, E) ->
+    %% FIXME: We don't have access to EDoc options here. Therefore we assume
+    %% that the EDoc directory is `doc' in the current working directory...
+    {ok, Cwd} = file:get_cwd(),
+    Dir = filename:join(Cwd, "doc"),
+    AddonFile = filename:join(Dir, ?HEAD_ADDON_FILENAME),
+    Data1 = case file:read_file(AddonFile) of
+                {ok, Addon} -> [Data, Addon];
+                _           -> Data
+            end,
+    xmerl_html:'#element#'(Tag, Data1, Attrs, Parents, E);
 '#element#'(body = Tag, Data, _Attrs, Parents, E) ->
     Data1 = [?SYNTAX_HIGHLIGHTING_JS,
              Data],


### PR DESCRIPTION
If the `doc/_head.html` file exists, its content will be added to the end of the `<head>...</head>` element.

This allows to set things such as a favicon in the documenation for instance.