### PR TITLE
Assume Unicode in the documentation

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,8 +15,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        otp: [23, 24, 25]
-        rebar: [3.18.0]
+        otp: [24, 25]
+        rebar: [3.20.0]
     steps:
     - uses: actions/checkout@v2
     - uses: erlef/setup-beam@v1

--- a/.gitignore
+++ b/.gitignore
@@ -12,4 +12,4 @@ _build
 log
 rebar3.crashdump
 _checkouts/
-doc
+/doc/

--- a/src/rebar3_edoc_extensions_wrapper.erl
+++ b/src/rebar3_edoc_extensions_wrapper.erl
@@ -73,17 +73,17 @@ patch_html(Dir, Html) ->
                   "<body +bgcolor=\"[^\"]*\">",
                   "<body class=\"" ?BODY_CLASSES "\">\n"
                   ?SYNTAX_HIGHLIGHTING_JS,
-                  [{return, list}]),
+                  [{return, list}, unicode]),
     Html3 = re:replace(
                   Html2,
                   "<pre>(.*)</pre>",
                   "<pre><code>\\1</code></pre>",
-                  [{return, list}, ungreedy, dotall, global]),
+                  [{return, list}, unicode, ungreedy, dotall, global]),
     Html4 = re:replace(
                   Html3,
                   "<pre><code> +(" ?LANG_REGEX ")(?:\n)(.*)</code></pre>",
                   "<pre><code class=\"language-\\1\">\\2</code></pre>",
-                  [{return, list}, ungreedy, dotall, global]),
+                  [{return, list}, unicode, ungreedy, dotall, global]),
     Html4.
 
 -spec add_head_addon(Dir, Html) -> Html when
@@ -97,7 +97,7 @@ add_head_addon(Dir, Html) ->
               Html,
               "</head>",
               [Addon, "</head>"],
-              [{return, list}]);
+              [{return, list}, unicode]);
         _ ->
             Html
     end.
@@ -112,7 +112,7 @@ add_toc(App, Html, Dir) ->
               Html,
               "(<h2 class=\"indextitle\">Modules</h2>)",
               Toc ++ "\\1",
-              [{return, list}])
+              [{return, list}, unicode])
     end.
 
 -spec generate_toc([binary() | list()], term()) -> [binary() | list()] | undefined.
@@ -121,19 +121,21 @@ generate_toc(Dir, App) ->
         undefined ->
             undefined;
         Overview ->
-            Lines = re:split(Overview, "\\n", [{return, list}]),
+            Lines = re:split(Overview, "\\n", [{return, list}, unicode]),
             Titles = [Line ||
                       Line <- Lines,
-                      match =:= re:run(Line, "^=+.*=+$", [{capture, none}])],
+                      match =:= re:run(Line, "^=+.*=+$",
+                                       [{capture, none}, unicode])],
             generate_toc1(Titles, 0, [], App)
     end.
 
 -spec generate_toc1([binary() | list()], integer(), list(), term()) -> [binary() | list()].
 generate_toc1([Title | Rest], CurrentLevel, Result, App) ->
-    ReOpts = [{capture, all_but_first, list}],
+    ReOpts = [{capture, all_but_first, list}, unicode],
     {match, [Equals, Title1]} = re:run(Title, "^(=+) *(.*)", ReOpts),
-    Title2 = re:replace(Title1, " *=+$", "", [{return, list}]),
-    Anchor = "#" ++ re:replace(Title2, " ", "_", [{return, list}, global]),
+    Title2 = re:replace(Title1, " *=+$", "", [{return, list}, unicode]),
+    Anchor = "#" ++ re:replace(
+                      Title2, " ", "_", [{return, list}, unicode, global]),
     Link = "<a href=\"overview-summary.html" ++ Anchor ++ "\"" ++
       "target=\"overviewFrame\">" ++ Title2 ++ "</a>",
     Level = length(Equals) - 1,

--- a/test/rebar3_edoc_extensions_SUITE.erl
+++ b/test/rebar3_edoc_extensions_SUITE.erl
@@ -61,14 +61,19 @@ test_app(_Config) ->
     ok = file:set_cwd("../../../../test"),
     State = init_test_app(),
     {Res, _} = edoc(State),
-    {ok, Bin} = file:read_file("test_app/doc/test.html"),
     ?assertEqual(ok, Res),
+
+    {ok, Bin} = file:read_file("test_app/doc/test.html"),
     ?assertEqual(true, filelib:is_file("test_app/doc/edoc-extensions.css")),
     ?assertEqual(true, filelib:is_file("test_app/doc/prism.js")),
     ?assertEqual(true, filelib:is_file("test_app/doc/prism.css")),
     ?assertEqual(true, filelib:is_file("test_app/doc/github-markdown.css")),
     ?assertEqual(true, nomatch /= re:run(Bin, "language-erlang")),
-    ?assertEqual(true, nomatch /= re:run(Bin, "edoc-extensions.css")).
+    ?assertEqual(true, nomatch /= re:run(Bin, "edoc-extensions.css")),
+
+    {ok, Overview} = file:read_file("test_app/doc/overview-summary.html"),
+    ?assertEqual(true, nomatch /= re:run(Overview, "Added to head element")),
+    ?assertEqual(true, nomatch /= re:run(Overview, "Some Unicode")).
 
 -spec command(list()) -> ok | no_return().
 command(_Config) ->

--- a/test/test_app/.gitignore
+++ b/test/test_app/.gitignore
@@ -1,0 +1,3 @@
+/doc/
+!/doc/overview.edoc
+!/doc/_head.html

--- a/test/test_app/doc/_head.html
+++ b/test/test_app/doc/_head.html
@@ -1,0 +1,2 @@
+<!-- Added to head element -->
+<link/>

--- a/test/test_app/doc/overview.edoc
+++ b/test/test_app/doc/overview.edoc
@@ -1,0 +1,10 @@
+@doc Test app for `rebar3_edoc_extensions'
+
+== Some Unicode characters ==
+
+Here are some Unicode characters for the test — which should succeed.
+
+<ul>
+<li>Ç</li>
+<li>É</li>
+</ul>


### PR DESCRIPTION
... and pass `unicode` to all regex calls.

Extend the testsuite to cover Unicode characters, as well as a working support for `_head.html`.