### PR TITLE
Support `#xmlText{}` of type `cdata`

### DIFF
--- a/src/rebar3_edoc_extensions_export.erl
+++ b/src/rebar3_edoc_extensions_export.erl
@@ -14,7 +14,7 @@
 
 -export(['#xml-inheritance#'/0]).
 
--export(['#root#'/4, '#element#'/5, '#text#'/1]).
+-export(['#root#'/4, '#element#'/5, '#text#'/1, '#cdata#'/1]).
 
 -spec '#xml-inheritance#'() -> [].
 '#xml-inheritance#'() -> [].
@@ -22,6 +22,10 @@
 -spec '#text#'(term()) -> term().
 '#text#'(Text) ->
     xmerl_html:'#text#'(Text).
+
+-spec '#cdata#'(term()) -> term().
+'#cdata#'(Text) ->
+    xmerl_html:'#cdata#'(Text).
 
 -spec '#root#'(term(), term(), [], term()) -> term().
 '#root#'(Data, Attrs, [], E) ->


### PR DESCRIPTION
## Why

These elements start to be emitted by xmerl in Erlang/OTP 27.1.

Without this, building the documentation could fail with:

```
edoc: error in layout 'rebar3_edoc_extensions_wrapper': {'EXIT', {unknown_tag, {'#cdata#', ...}}}
```

## How

We simply wrap the corresponding `xmerl_html:'#cdata#'/1` function.